### PR TITLE
Only attempt to cache GET requests

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,7 +19,7 @@ var globalOptions = require('./options');
 
 function debug(message, options) {
   options = options || {};
-  var flag = options.debug || globalOptions.debug;  
+  var flag = options.debug || globalOptions.debug;
   if (flag) {
     console.log('[sw-toolbox] ' + message);
   }
@@ -34,11 +34,11 @@ function openCache(options) {
 
 function fetchAndCache(request, options) {
   options = options || {};
-  var successResponses = options.successResponses || globalOptions.successResponses;  
+  var successResponses = options.successResponses || globalOptions.successResponses;
   return fetch(request.clone()).then(function(response) {
 
-    // Only cache successful responses
-    if (successResponses.test(response.status)) {
+    // Only cache GET requests with successful responses
+    if (request.method === 'GET' && successResponses.test(response.status)) {
       openCache(options).then(function(cache) {
         cache.put(request, response);
       });


### PR DESCRIPTION
Caching other types of request is prohibited by the spec and can result in console error spam.

Closes #10 

R: @addyosmani @jeffposnick