### PR TITLE
Fixed #21 for networkFirst strategy

### DIFF
--- a/lib/strategies/networkFirst.js
+++ b/lib/strategies/networkFirst.js
@@ -29,13 +29,13 @@ function networkFirst(request, values, options) {
 
       return cache.match(request).then(function(cacheResponse) {
         helpers.debug('Response was an HTTP error', options);
-        if (cacheResponse) {
+        if (cacheResponse && request.method === 'GET') {
           helpers.debug('Resolving with cached response instead', options);
           return cacheResponse;
         } else {
           // If we didn't have anything in the cache, it's better to return the
           // error page than to return nothing
-          helpers.debug('No cached result, resolving with HTTP error response from network', options);
+          helpers.debug('No cached result or non-GET request, resolving with HTTP error response from network', options);
           return response;
         }
       });


### PR DESCRIPTION
- This is a pretty naive fix to handle the happy path
- Similar fixes are needed for other strategies

Doesn't handle L44 with issue of a network error. Realistically, given the prominent use of cache.match in all strategies, it may make more sense to create a proper wrapper to do this check.