### PR TITLE
Fixes #21. The default route should only apply to GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ toolbox.router.get(':foo/index.html', function(request, values) {
 // For requests to other origins, specify the origin as an option
 toolbox.router.post('/(.*)', apiHandler, {origin: 'https://api.example.com'});
 
-// Provide a default handler
+// Provide a default handler for GET requests
 toolbox.router.default = myDefaultRequestHandler;
 
 // You can provide a list of resources which will be cached at service worker install time
@@ -128,7 +128,7 @@ Create a route that causes requests for URLs matching `urlPattern` to be resolve
 Like `toolbox.router.get`, etc., but matches any HTTP method.
 
 ### `toolbox.router.default`
-If you set this property to a function it will be used as the request handler for any request that does not match a route.
+If you set this property to a function it will be used as the request handler for any GET request that does not match a route.
 
 ### `toolbox.precache(arrayOfURLs)`
 Add each URL in arrayOfURLs to the list of resources that should be cached during the service worker install step. Note that this needs to be called before the install event is triggered, so you should do it on the first run of your script.

--- a/lib/sw-toolbox.js
+++ b/lib/sw-toolbox.js
@@ -62,7 +62,7 @@ self.addEventListener('fetch', function(event) {
 
   if (handler) {
     event.respondWith(handler(event.request));
-  } else if (router.default) {
+  } else if (router.default && event.request.method === 'GET') {
     event.respondWith(router.default(event.request));
   }
 });


### PR DESCRIPTION
R: @jeffposnick 

I can't work out if this is controversial or not. Since you can't cache non-GET requests, it seems safe to me.