### PR TITLE
Fixing options bug in fastest strategy

### DIFF
--- a/lib/strategies/fastest.js
+++ b/lib/strategies/fastest.js
@@ -44,7 +44,7 @@ function fastest(request, values, options) {
     helpers.fetchAndCache(request.clone(), options)
       .then(maybeResolve, maybeReject);
 
-    cacheOnly(request, options)
+    cacheOnly(request, values, options)
       .then(maybeResolve, maybeReject);
   });
 }


### PR DESCRIPTION
cacheOnly has the following signature 
`function cacheOnly(request, values, options){ ... }`