### PR TITLE
Responding with original Network error response incase of cache miss

### DIFF
--- a/lib/strategies/networkFirst.js
+++ b/lib/strategies/networkFirst.js
@@ -28,6 +28,7 @@ function networkFirst(request, values, options) {
   return helpers.openCache(options).then(function(cache) {
     var timeoutId;
     var promises = [];
+    var originalResponse;
 
     if (networkTimeoutSeconds) {
       var cacheWhenTimedOutPromise = new Promise(function(resolve) {
@@ -56,10 +57,13 @@ function networkFirst(request, values, options) {
       }
 
       helpers.debug('Response was an HTTP error: ' + response.statusText, options);
+      originalResponse = response;
       throw new Error('Bad response');
     }).catch(function() {
       helpers.debug('Network or response error, fallback to cache [' + request.url + ']', options);
-      return cache.match(request);
+      return cache.match(request).then(function(response) {
+        return response || originalResponse;
+      });
     });
     promises.push(networkPromise);
 


### PR DESCRIPTION
Currently if there is network error such as a 500 and a cache miss we see the error :

`The FetchEvent for "xyz" resulted in a network error response: an object that was not a Response was passed to respondWith()`

This fix passes through correct error response incase of cache miss.