### PR TITLE
Follow up to #101. Ensure that the `RegExp` origin always exists.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -39,6 +39,8 @@ var keyMatch = function(map, string) {
 
 var Router = function() {
   this.routes = new Map();
+  // Create the dummy origin for RegExp-based routes
+  this.routes.set(RegExp, new Map());
   this.default = null;
 };
 


### PR DESCRIPTION
R: @gauntface @jeffposnick 