### PR TITLE
Companion: Avoid old IE errors with document.currentScript

### DIFF
--- a/companion.js
+++ b/companion.js
@@ -15,7 +15,7 @@
 */
 (function() {
   'use strict';
-  var workerScript = document.currentScript.dataset.serviceWorker;
+  var workerScript = document.currentScript && document.currentScript.dataset.serviceWorker;
 
   if (workerScript && 'serviceWorker' in navigator) {
     navigator.serviceWorker.register(workerScript);


### PR DESCRIPTION
This PR fixes the errors `TypeError: Unable to get property 'dataset' of undefined or null reference` on IE <= 11.

Thanks!
Vincent