### PR TITLE
Use NPM Versioning for Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/sw-toolbox.js",
   "repository": "https://github.com/GoogleChrome/sw-toolbox",
   "dependencies": {
-    "serviceworker-cache-polyfill": "coonsta/cache-polyfill",
+    "serviceworker-cache-polyfill": "^3.0.0",
     "path-to-regexp": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Use NPM versioning for the serviceworker-cache-polyfill dependency instead of github reference.

Our tooling disallows us from using dependencies specified like "coonsta/cache-polyfill", so we can't use sw-toolbox until the dependency specification is fixed.