### PR TITLE
Update cache-polyfill to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/sw-toolbox.js",
   "repository": "https://github.com/GoogleChrome/sw-toolbox",
   "dependencies": {
-    "serviceworker-cache-polyfill": "^3.0.0",
+    "serviceworker-cache-polyfill": "^4.0.0",
     "path-to-regexp": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
#112 got merged without updating the dependency to 4.0.0. It seemed there was desire for v4 so here's a PR for the upgrade.