### PR TITLE
clean up redundant caches. domain global though

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -132,9 +132,29 @@ function renameCache(source, destination, options) {
   });
 }
 
+
+function renameCacheAndCleanUp(source, destination, options) {
+  debug('Renaming cache: [' + source + '] to [' + destination + ']', options);
+
+  return caches.keys().then(function(cacheNames) {
+    Promise.all(
+
+      cacheNames.map(function(cacheName) {
+        if (destination !== cacheName && source !== cacheName) {
+          return caches.delete(cacheName);
+        }
+      })
+
+    ).then(function() {
+      return renameCache(source, destination, options);
+    });
+  });
+}
+
 module.exports = {
   debug: debug,
   fetchAndCache: fetchAndCache,
   openCache: openCache,
-  renameCache: renameCache
+  renameCache: renameCache,
+  renameCacheAndCleanUp: renameCacheAndCleanUp
 };

--- a/lib/sw-toolbox.js
+++ b/lib/sw-toolbox.js
@@ -73,7 +73,7 @@ self.addEventListener('install', function(event) {
 self.addEventListener('activate', function(event) {
   helpers.debug('activate event fired');
   var inactiveCache = options.cache.name + '$$$inactive$$$';
-  event.waitUntil(helpers.renameCache(inactiveCache, options.cache.name));
+  event.waitUntil(helpers.renameCacheAndCleanUp(inactiveCache, options.cache.name));
 });
 
 // Fetch


### PR DESCRIPTION
On several projects, where I've used sw-toolbox, I'm using versioning numbers as well to invalidate all my files at once - when it's needed of course.
Only problem is, that I ended up having multiple redundant caches, that basically just filled up space.

The challenge in removing redundant caches is the fact, that it's removing it form the whole domain.
Meaning if the website has a subsite under /serviceworker/is/the/best using a scoped serviceworker, their cache might all of a sudden not be available.

I'm not sure how to solve this yet, but I really badly needed the clean up and thought I might as well just implement it my self :)

How should we go around this?