### PR TITLE
NetworkFirst: return responses on client errors

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -36,5 +36,9 @@ module.exports = {
   // A regular expression to apply to HTTP response codes. Codes that match
   // will be considered successes, while others will not, and will not be
   // cached.
-  successResponses: /^0|([123]\d\d)|(40[14567])|410$/
+  successResponses: /^0|([123]\d\d)|(40[14567])|410$/,
+  // HTTP Errors codes that match will be returned to the client and will
+  // not fallback to a cached response. For example we had a 200 cached and
+  // our `toolbox.networkFirst` now returns 403.
+  errorsResponsesWithoutCacheFallback: /^4\d\d$/
 };

--- a/lib/strategies/networkFirst.js
+++ b/lib/strategies/networkFirst.js
@@ -21,6 +21,9 @@ function networkFirst(request, values, options) {
   options = options || {};
   var successResponses = options.successResponses ||
       globalOptions.successResponses;
+  var errorsResponsesWithoutCacheFallback =
+      options.errorsResponsesWithoutCacheFallback ||
+      globalOptions.errorsResponsesWithoutCacheFallback;
   // This will bypass options.networkTimeout if it's set to a false-y value like
   // 0, but that's the sane thing to do anyway.
   var networkTimeoutSeconds = options.networkTimeoutSeconds ||
@@ -56,7 +59,9 @@ function networkFirst(request, values, options) {
           clearTimeout(timeoutId);
         }
 
-        if (successResponses.test(response.status)) {
+        // We've got a success response or client error, let's return it
+        if (successResponses.test(response.status) ||
+            errorsResponsesWithoutCacheFallback.test(response.status)) {
           return response;
         }
 

--- a/test/browser-tests/network-first/network-first.js
+++ b/test/browser-tests/network-first/network-first.js
@@ -65,7 +65,7 @@ describe('Test toolbox.networkFirst', function() {
     });
   });
 
-  it.skip('should retrieve the value from the cache for a bad network request', function() {
+  it('should retrieve the value from the cache for a bad network request', function() {
     let iframe;
     const TEST_INPUT = 'hello';
     return swUtils.activateSW(serviceWorkersFolder + '/network-first.js')
@@ -76,11 +76,11 @@ describe('Test toolbox.networkFirst', function() {
       return window.caches.open('test-cache-name');
     })
     .then(cache => {
-      return cache.put('/test/browser-tests/network-first/doesnt-exist', new Response(TEST_INPUT));
+      return cache.put('/test/browser-tests/network-first/503', new Response(TEST_INPUT));
     })
     .then(() => {
       // Call the iframes fetch event so it goes through the service worker
-      return iframe.contentWindow.fetch('/test/browser-tests/network-first/doesnt-exist');
+      return iframe.contentWindow.fetch('/test/browser-tests/network-first/503');
     })
     .then(response => {
       response.status.should.equal(200);
@@ -93,13 +93,41 @@ describe('Test toolbox.networkFirst', function() {
       return window.caches.open('test-cache-name');
     })
     .then(cache => {
-      return cache.match('/test/browser-tests/network-first/doesnt-exist');
+      return cache.match('/test/browser-tests/network-first/503');
     })
     .then(response => {
       return response.text();
     })
     .then(responseText => {
       responseText.trim().should.equal(TEST_INPUT);
+    });
+  });
+
+  it('should retreive the response for a client error that was previously cached as ok', function() {
+    let iframe;
+    const TEST_INPUT = 'hello';
+    return swUtils.activateSW(serviceWorkersFolder + '/network-first.js')
+    .then(newIframe => {
+      iframe = newIframe;
+    })
+    .then(() => {
+      return window.caches.open('test-cache-name');
+    })
+    .then(cache => {
+      return cache.put('/test/browser-tests/network-first/403', new Response(TEST_INPUT));
+    })
+    .then(() => {
+      // Call the iframes fetch event so it goes through the service worker
+      return iframe.contentWindow.fetch('/test/browser-tests/network-first/403');
+    })
+    .then(response => {
+      response.status.should.equal(403);
+    })
+    .then(() => {
+      return window.caches.open('test-cache-name');
+    })
+    .then(cache => {
+      return cache.match('/test/browser-tests/network-first/503');
     });
   });
 

--- a/test/browser-tests/network-first/serviceworkers/network-first.js
+++ b/test/browser-tests/network-first/serviceworkers/network-first.js
@@ -25,3 +25,5 @@ self.toolbox.options.cache.name = 'test-cache-name';
 
 self.toolbox.router.get('/test/data/files/text.txt', self.toolbox.networkFirst);
 self.toolbox.router.get('/test/browser-tests/network-first/doesnt-exist', self.toolbox.networkFirst);
+self.toolbox.router.get('/test/browser-tests/network-first/503', self.toolbox.networkFirst);
+self.toolbox.router.get('/test/browser-tests/network-first/403', self.toolbox.networkFirst);

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -83,6 +83,14 @@ function startServer(staticAssetsPath, portNumber) {
     });
   });
 
+  app.get('/test/browser-tests/network-first/503', function(req, res) {
+    res.sendStatus(503);
+  });
+
+  app.get('/test/browser-tests/network-first/403', function(req, res) {
+    res.sendStatus(403);
+  });
+
   return new Promise(resolve => {
     // Start service on desired port
     _server = app.listen(portNumber, function() {


### PR DESCRIPTION
When a success response was cached and the newly returned response
was a client error (e.g. 402, 403), this error was ignored and the
cache was returned. The new behavior is to directly return those
client errors and avoiding to fallback on the existing cache.
