### PR TITLE
implements oldest first cache expiry option

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -84,6 +84,7 @@ function cleanupCache(request, cache, cacheOptions) {
   var requestUrl = request.url;
   var maxAgeSeconds = cacheOptions.maxAgeSeconds;
   var maxEntries = cacheOptions.maxEntries;
+  var expireOldestFirst = cacheOptions.expireOldestFirst;
   var cacheName = cacheOptions.name;
 
   var now = Date.now();
@@ -93,7 +94,7 @@ function cleanupCache(request, cache, cacheOptions) {
   return idbCacheExpiration.getDb(cacheName).then(function(db) {
     return idbCacheExpiration.setTimestampForUrl(db, requestUrl, now);
   }).then(function(db) {
-    return idbCacheExpiration.expireEntries(db, maxEntries, maxAgeSeconds, now);
+    return idbCacheExpiration.expireEntries(db, maxEntries, maxAgeSeconds, expireOldestFirst, now);
   }).then(function(urlsToDelete) {
     debug('Successfully updated IDB.');
 

--- a/lib/idb-cache-expiration.js
+++ b/lib/idb-cache-expiration.js
@@ -102,7 +102,7 @@ function expireOldEntries(db, maxAgeSeconds, now) {
   });
 }
 
-function expireExtraEntries(db, maxEntries) {
+function expireExtraEntries(db, maxEntries, oldestFirst) {
   // Bail out early by resolving with an empty array if we're not using
   // maxEntries.
   if (!maxEntries) {
@@ -121,7 +121,9 @@ function expireExtraEntries(db, maxEntries) {
       var initialCount = countRequest.result;
 
       if (initialCount > maxEntries) {
-        index.openCursor().onsuccess = function(cursorEvent) {
+        index.openCursor({
+          direction: oldestFirst ? 'prev' : 'next'
+        }).onsuccess = function(cursorEvent) {
           var cursor = cursorEvent.target.result;
           if (cursor) {
             var url = cursor.value[URL_PROPERTY];
@@ -143,9 +145,9 @@ function expireExtraEntries(db, maxEntries) {
   });
 }
 
-function expireEntries(db, maxEntries, maxAgeSeconds, now) {
+function expireEntries(db, maxEntries, maxAgeSeconds, expireOldestFirst, now) {
   return expireOldEntries(db, maxAgeSeconds, now).then(function(oldUrls) {
-    return expireExtraEntries(db, maxEntries).then(function(extraUrls) {
+    return expireExtraEntries(db, maxEntries, expireOldestFirst).then(function(extraUrls) {
       return oldUrls.concat(extraUrls);
     });
   });

--- a/lib/options.js
+++ b/lib/options.js
@@ -28,7 +28,8 @@ module.exports = {
   cache: {
     name: '$$$toolbox-cache$$$' + scope + '$$$',
     maxAgeSeconds: null,
-    maxEntries: null
+    maxEntries: null,
+    expireOldestFirst: false
   },
   debug: false,
   networkTimeoutSeconds: null,


### PR DESCRIPTION
Hello,

This PR implements 'first in first out' cache expiry where maxEntries is set.

Personally I think this would make more sense as the default behaviour, though for backwards compatibility this PR, offering an easy way to configure via global options, seems like a less controversial offering

If you're happy with this in principle I'll add tests and docs
