### PR TITLE
chrome-extension requests shouldn't trigger the default route

### DIFF
--- a/lib/sw-toolbox.js
+++ b/lib/sw-toolbox.js
@@ -83,7 +83,10 @@ self.addEventListener('fetch', function(event) {
 
   if (handler) {
     event.respondWith(handler(event.request));
-  } else if (router.default && event.request.method === 'GET') {
+  } else if (router.default &&
+    event.request.method === 'GET' &&
+    // Ensure that chrome-extension:// requests don't trigger the default route.
+    event.request.url.indexOf('http') === 0) {
     event.respondWith(router.default(event.request));
   }
 });


### PR DESCRIPTION
R: @addyosmani @gauntface 

Explicitly check to make sure that the request URL starts with `'http'` before triggering the default route.

Fixes #171 