### PR TITLE
Use uglify instead of minifify and fix up sourcemap generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,14 +15,18 @@
 */
 'use strict';
 
-var path = require('path');
 var browserify = require('browserify');
+var buffer = require('vinyl-buffer');
 var eslint = require('gulp-eslint');
 var ghPages = require('gulp-gh-pages');
 var gulp = require('gulp');
+var header = require('gulp-header');
+var path = require('path');
 var source = require('vinyl-source-stream');
+var sourcemaps = require('gulp-sourcemaps');
 var temp = require('temp').track();
 var testServer = require('./test/server/index.js');
+var uglify = require('gulp-uglify');
 
 var buildSources = ['lib/**/*.js'];
 var lintSources = buildSources.concat([
@@ -30,29 +34,29 @@ var lintSources = buildSources.concat([
   'recipes/**/*.js',
   'test/**/*.js']);
 
-gulp.task('test:manual', function() {
+gulp.task('test:manual', ['build'], function() {
   testServer.startServer(path.join(__dirname), 8888)
-  .then(portNumber => {
-    console.log(`Tests are available at http://localhost:${portNumber}`);
-  });
+    .then(portNumber => {
+      console.log(`Tests are available at http://localhost:${portNumber}`);
+    });
+});
+
+var bundler = browserify({
+  entries: ['./lib/sw-toolbox.js'],
+  standalone: 'toolbox',
+  debug: true
 });
 
 gulp.task('build', function() {
-  var bundler = browserify({
-    entries: ['./lib/sw-toolbox.js'],
-    standalone: 'toolbox',
-    debug: true
-  });
-
-  bundler.plugin('browserify-header');
-  bundler.plugin('minifyify', {
-    map: './build/sw-toolbox.map.json',
-    output: './build/sw-toolbox.map.json'
-  });
-
+  var license = '/* \n Copyright 2016 Google Inc. All Rights Reserved.\n\n Licensed under the Apache License, Version 2.0 (the "License");\n you may not use this file except in compliance with the License.\n You may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\n Unless required by applicable law or agreed to in writing, software\n distributed under the License is distributed on an "AS IS" BASIS,\n WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n See the License for the specific language governing permissions and\n limitations under the License.\n*/';
   return bundler
     .bundle()
     .pipe(source('sw-toolbox.js'))
+    .pipe(buffer())
+    .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(uglify())
+    .pipe(header(license))
+    .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('./build/'));
 });
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "path-to-regexp": "^1.0.1"
   },
   "devDependencies": {
-    "browserify": "^12.0.1",
-    "browserify-header": "^0.9.2",
+    "browserify": "^13.1.0",
     "chai": "^3.4.1",
     "chromedriver": "^2.24.1",
     "cookie-parser": "^1.4.1",
@@ -30,9 +29,11 @@
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.1.1",
     "gulp-gh-pages": "^0.5.4",
+    "gulp-header": "^1.8.8",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-uglify": "^2.0.0",
     "jsdoc": "^3.4.0",
     "jshint-stylish": "^2.1.0",
-    "minifyify": "^7.1.0",
     "mocha": "^2.3.4",
     "npm-publish-scripts": "^2.0.7",
     "operadriver": "^0.2.2",
@@ -41,6 +42,7 @@
     "selenium-webdriver": "^3.0.0-beta-2",
     "sw-testing-helpers": "0.1.4",
     "temp": "^0.8.3",
+    "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "which": "^1.2.4"
   },


### PR DESCRIPTION
R: @addyosmani @gauntface 

Going with `uglify` as recommended in the [`gulp` docs](https://github.com/gulpjs/gulp/blob/master/docs/recipes/browserify-uglify-sourcemap.md) seems to lead to a better-behaving sourcemap when used from Chrome's debugger.

It also leads to a slightly smaller final bundle (15kb vs 17kb with `minifify`).

This also fixes up the URL pointing to the sourcemap file, telling the debugger to look for the sourcemap in the same directory as the `sw-toolbox.js` library, rather than in a `./build/` subdirectory.

I decided to just inline the Apache 2.0 license header that gets prepending to the generated library, but if you think it's too messy that way, I can put it in a standalone file and then call `fs.readFileSync()` to bring it into the build.

Fixes #169 