### PR TITLE
Fix some paths in the cache-expiration-options recipe

### DIFF
--- a/docs/recipes/cache-expiration-options/index.html
+++ b/docs/recipes/cache-expiration-options/index.html
@@ -1,7 +1,6 @@
 <html>
   <head>
     <title>Cache Expiration Demo</title>
-    <link rel="stylesheet" href="../common.css">
     <link rel="stylesheet" href="styles.css">
     <script>
       // If we're running on a real web server (as opposed to localhost, which is whitelisted),

--- a/docs/recipes/cache-expiration-options/service-worker.js
+++ b/docs/recipes/cache-expiration-options/service-worker.js
@@ -2,7 +2,7 @@
   'use strict';
 
   // Load the sw-tookbox library.
-  importScripts('../../sw-toolbox.js');
+  importScripts('/build/sw-toolbox.js');
 
   // Turn on debug logging, visible in the Developer Tools' console.
   global.toolbox.options.debug = true;


### PR DESCRIPTION
R: @addyosmani @gauntface 

Nothing major here. Just fixing some paths up so that they work by default when run locally.