### PR TITLE
Separate pure and side-effecting code

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -132,9 +132,52 @@ function renameCache(source, destination, options) {
   });
 }
 
+function cache(url, options) {
+  return openCache(options).then(function(cache) {
+    return cache.add(url);
+  });
+}
+
+function uncache(url, options) {
+  return openCache(options).then(function(cache) {
+    return cache.delete(url);
+  });
+}
+
+function precache(items) {
+  if (!(items instanceof Promise)) {
+    validatePrecacheInput(items);
+  }
+
+  globalOptions.preCacheItems = globalOptions.preCacheItems.concat(items);
+}
+
+function validatePrecacheInput(items) {
+  var isValid = Array.isArray(items);
+  if (isValid) {
+    items.forEach(function(item) {
+      if (!(typeof item === 'string' || (item instanceof Request))) {
+        isValid = false;
+      }
+    });
+  }
+
+  if (!isValid) {
+    throw new TypeError('The precache method expects either an array of ' +
+    'strings and/or Requests or a Promise that resolves to an array of ' +
+    'strings and/or Requests.');
+  }
+
+  return items;
+}
+
 module.exports = {
   debug: debug,
   fetchAndCache: fetchAndCache,
   openCache: openCache,
-  renameCache: renameCache
+  renameCache: renameCache,
+  cache: cache,
+  uncache: uncache,
+  precache: precache,
+  validatePrecacheInput: validatePrecacheInput
 };

--- a/lib/listeners.js
+++ b/lib/listeners.js
@@ -1,0 +1,75 @@
+/*
+  Copyright 2014 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+'use strict';
+
+// For cache.addAll.
+require('serviceworker-cache-polyfill');
+
+var helpers = require('./helpers');
+var router = require('./router');
+var options = require('./options');
+
+// Event listeners
+
+function fetchListener(event) {
+  var handler = router.match(event.request);
+
+  if (handler) {
+    event.respondWith(handler(event.request));
+  } else if (router.default &&
+    event.request.method === 'GET' &&
+    // Ensure that chrome-extension:// requests don't trigger the default route.
+    event.request.url.indexOf('http') === 0) {
+    event.respondWith(router.default(event.request));
+  }
+}
+
+function activateListener(event) {
+  helpers.debug('activate event fired');
+  var inactiveCache = options.cache.name + '$$$inactive$$$';
+  event.waitUntil(helpers.renameCache(inactiveCache, options.cache.name));
+}
+
+function flatten(items) {
+  return items.reduce(function(a, b) {
+    return a.concat(b);
+  }, []);
+}
+
+function installListener(event) {
+  var inactiveCache = options.cache.name + '$$$inactive$$$';
+  helpers.debug('install event fired');
+  helpers.debug('creating cache [' + inactiveCache + ']');
+  event.waitUntil(
+    helpers.openCache({cache: {name: inactiveCache}})
+    .then(function(cache) {
+      return Promise.all(options.preCacheItems)
+      .then(flatten)
+      .then(helpers.validatePrecacheInput)
+      .then(function(preCacheItems) {
+        helpers.debug('preCache list: ' +
+              (preCacheItems.join(', ') || '(none)'));
+        return cache.addAll(preCacheItems);
+      });
+    })
+  );
+}
+
+module.exports = {
+  fetchListener: fetchListener,
+  activateListener: activateListener,
+  installListener: installListener
+};

--- a/lib/sw-toolbox.js
+++ b/lib/sw-toolbox.js
@@ -15,103 +15,22 @@
 */
 'use strict';
 
-require('serviceworker-cache-polyfill');
+// This is the entrypoint for the sw-toolbox bundle. All code with
+// side effects (e.g. adding event listeners) should be in this file.
+
 var options = require('./options');
 var router = require('./router');
 var helpers = require('./helpers');
 var strategies = require('./strategies');
+var listeners = require('./listeners');
 
 helpers.debug('Service Worker Toolbox is loading');
 
-// Install
-var flatten = function(items) {
-  return items.reduce(function(a, b) {
-    return a.concat(b);
-  }, []);
-};
+// Set up listeners.
 
-var validatePrecacheInput = function(items) {
-  var isValid = Array.isArray(items);
-  if (isValid) {
-    items.forEach(function(item) {
-      if (!(typeof item === 'string' || (item instanceof Request))) {
-        isValid = false;
-      }
-    });
-  }
-
-  if (!isValid) {
-    throw new TypeError('The precache method expects either an array of ' +
-    'strings and/or Requests or a Promise that resolves to an array of ' +
-    'strings and/or Requests.');
-  }
-
-  return items;
-};
-
-self.addEventListener('install', function(event) {
-  var inactiveCache = options.cache.name + '$$$inactive$$$';
-  helpers.debug('install event fired');
-  helpers.debug('creating cache [' + inactiveCache + ']');
-  event.waitUntil(
-    helpers.openCache({cache: {name: inactiveCache}})
-    .then(function(cache) {
-      return Promise.all(options.preCacheItems)
-      .then(flatten)
-      .then(validatePrecacheInput)
-      .then(function(preCacheItems) {
-        helpers.debug('preCache list: ' +
-            (preCacheItems.join(', ') || '(none)'));
-        return cache.addAll(preCacheItems);
-      });
-    })
-  );
-});
-
-// Activate
-
-self.addEventListener('activate', function(event) {
-  helpers.debug('activate event fired');
-  var inactiveCache = options.cache.name + '$$$inactive$$$';
-  event.waitUntil(helpers.renameCache(inactiveCache, options.cache.name));
-});
-
-// Fetch
-
-self.addEventListener('fetch', function(event) {
-  var handler = router.match(event.request);
-
-  if (handler) {
-    event.respondWith(handler(event.request));
-  } else if (router.default &&
-    event.request.method === 'GET' &&
-    // Ensure that chrome-extension:// requests don't trigger the default route.
-    event.request.url.indexOf('http') === 0) {
-    event.respondWith(router.default(event.request));
-  }
-});
-
-// Caching
-
-function cache(url, options) {
-  return helpers.openCache(options).then(function(cache) {
-    return cache.add(url);
-  });
-}
-
-function uncache(url, options) {
-  return helpers.openCache(options).then(function(cache) {
-    return cache.delete(url);
-  });
-}
-
-function precache(items) {
-  if (!(items instanceof Promise)) {
-    validatePrecacheInput(items);
-  }
-
-  options.preCacheItems = options.preCacheItems.concat(items);
-}
+self.addEventListener('install', listeners.installListener);
+self.addEventListener('activate', listeners.activateListener);
+self.addEventListener('fetch', listeners.fetchListener);
 
 module.exports = {
   networkOnly: strategies.networkOnly,
@@ -121,7 +40,7 @@ module.exports = {
   fastest: strategies.fastest,
   router: router,
   options: options,
-  cache: cache,
-  uncache: uncache,
-  precache: precache
+  cache: helpers.cache,
+  uncache: helpers.uncache,
+  precache: helpers.precache
 };


### PR DESCRIPTION
To make it easier to use sw-toolbox as a library, this PR moves all the helper and listener functions out of sw-toolbox.js so they can be imported without setting up the event listeners.

Tests in Chrome 51 pass locally.