### PR TITLE
RFC: Pass 'event' instead of 'request'

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,8 +46,8 @@ Some examples of using Express-style routing include:
 ```javascript
 // URL patterns are the same syntax as Express routes
 // (http://expressjs.com/guide/routing.html)
-toolbox.router.get(':foo/index.html', function(request, values) {
-  return new Response('Handled a request for ' + request.url +
+toolbox.router.get(':foo/index.html', function(event, values) {
+  return new Response('Handled a request for ' + event.request.url +
       ', where foo is "' + values.foo + '"');
 });
 
@@ -75,8 +75,8 @@ Some examples of using Regular Expression routing include:
 
 ```javascript
 // Match URLs that end in index.html
-toolbox.router.get(/index.html$/, function(request) {
-  return new Response('Handled a request for ' + request.url);
+toolbox.router.get(/index.html$/, function(event) {
+  return new Response('Handled a request for ' + event.request.url);
 });
 
 // Match URLs that begin with https://api.example.com
@@ -109,13 +109,14 @@ toolbox.precache(['/index.html', '/site.css', '/images/logo.png']);
 A request handler takes three arguments.
 
 ```javascript
-var myHandler = function(request, values, options) {
+var myHandler = function(event, values, options) {
   // ...
 }
 ```
 
-- `request` - The [Request](https://fetch.spec.whatwg.org/#request) object that
-triggered the `fetch` event
+- `event` - The [FetchEvent](https://www.w3.org/TR/service-workers/#fetch-event-section)
+object that triggered the `fetch` event. Access the
+[Request](https://fetch.spec.whatwg.org/#request) object with `event.request`.
 - `values` - When using Express-style routing paths, this will be an object
 whose keys are the placeholder names in the URL pattern, with the values being
 the corresponding part of the request URL. For example, with a URL pattern of

--- a/lib/listeners.js
+++ b/lib/listeners.js
@@ -28,12 +28,12 @@ function fetchListener(event) {
   var handler = router.match(event.request);
 
   if (handler) {
-    event.respondWith(handler(event.request));
+    event.respondWith(handler(event));
   } else if (router.default &&
     event.request.method === 'GET' &&
     // Ensure that chrome-extension:// requests don't trigger the default route.
     event.request.url.indexOf('http') === 0) {
-    event.respondWith(router.default(event.request));
+    event.respondWith(router.default(event));
   }
 }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -52,8 +52,8 @@ Route.prototype.makeHandler = function(url) {
     });
   }
 
-  return function(request) {
-    return this.handler(request, values, this.options);
+  return function(event) {
+    return this.handler(event, values, this.options);
   }.bind(this);
 };
 

--- a/lib/strategies/cacheFirst.js
+++ b/lib/strategies/cacheFirst.js
@@ -16,7 +16,8 @@
 'use strict';
 var helpers = require('../helpers');
 
-function cacheFirst(request, values, options) {
+function cacheFirst(event, values, options) {
+  var request = event.request;
   helpers.debug('Strategy: cache first [' + request.url + ']', options);
   return helpers.openCache(options).then(function(cache) {
     return cache.match(request).then(function(response) {

--- a/lib/strategies/cacheOnly.js
+++ b/lib/strategies/cacheOnly.js
@@ -16,7 +16,8 @@
 'use strict';
 var helpers = require('../helpers');
 
-function cacheOnly(request, values, options) {
+function cacheOnly(event, values, options) {
+  var request = event.request;
   helpers.debug('Strategy: cache only [' + request.url + ']', options);
   return helpers.openCache(options).then(function(cache) {
     return cache.match(request);

--- a/lib/strategies/fastest.js
+++ b/lib/strategies/fastest.js
@@ -17,7 +17,8 @@
 var helpers = require('../helpers');
 var cacheOnly = require('./cacheOnly');
 
-function fastest(request, values, options) {
+function fastest(event, values, options) {
+  var request = event.request;
   helpers.debug('Strategy: fastest [' + request.url + ']', options);
 
   return new Promise(function(resolve, reject) {
@@ -45,7 +46,7 @@ function fastest(request, values, options) {
     helpers.fetchAndCache(request.clone(), options)
       .then(maybeResolve, maybeReject);
 
-    cacheOnly(request, values, options)
+    cacheOnly(event, values, options)
       .then(maybeResolve, maybeReject);
   });
 }

--- a/lib/strategies/networkFirst.js
+++ b/lib/strategies/networkFirst.js
@@ -17,7 +17,8 @@
 var globalOptions = require('../options');
 var helpers = require('../helpers');
 
-function networkFirst(request, values, options) {
+function networkFirst(event, values, options) {
+  var request = event.request;
   options = options || {};
   var successResponses = options.successResponses ||
       globalOptions.successResponses;

--- a/lib/strategies/networkOnly.js
+++ b/lib/strategies/networkOnly.js
@@ -16,7 +16,8 @@
 'use strict';
 var helpers = require('../helpers');
 
-function networkOnly(request, values, options) {
+function networkOnly(event, values, options) {
+  var request = event.request;
   helpers.debug('Strategy: network only [' + request.url + ']', options);
   return fetch(request);
 }


### PR DESCRIPTION
This PR updates request handlers to take `event` instead of `request` as their first argument, as discussed in #196. Request handlers need access to `event` because people that build on top of sw-toolbox may need access to `event.client` and `event.waitUntil`.

I didn't move event.respondWith inside of the event handlers because it seemed potentially error-prone and more verbose, because event.respondWith has to be called synchronously inside of the handler.

Looking at this, I'm not 100% sure it's worth breaking backwards compatibility.

Two alternatives:
- Pass in the event object as the last arg: `handler(request, values, options, event)`
- Add the event object to "options" (which overloads the use of options, which is currently only to override cache options):

```
handler(request, values, options) {
  // use options.event here
```

Thoughts?
