### PR TITLE
Further tweaks to package.json's files field

### DIFF
--- a/docs/recipes/cache-expiration-options/index.html
+++ b/docs/recipes/cache-expiration-options/index.html
@@ -69,6 +69,6 @@
     <div id="results"></div>
 
     <script src="app.js"></script>
-    <script src="../../companion.js" data-service-worker="service-worker.js"></script>
+    <script src="/companion.js" data-service-worker="service-worker.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "which": "^1.2.4"
   },
   "files": [
-    "build/",
     "lib/",
     "companion.js"
   ]

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
   },
   "files": [
     "lib/",
-    "companion.js"
+    "companion.js",
+    "sw-toolbox.js",
+    "sw-toolbox.js.map"
   ]
 }


### PR DESCRIPTION
R: @gauntface 
CC: @addyosmani 

I was taking another look at the publishing process prior to cutting the new release of `sw-toolbox`, and I realized that the output of the `build/` directory is explicitly copied over to the top-level directory via [`npm-publish-scripts`](https://github.com/GoogleChrome/npm-publish-scripts/blob/master/project/create-release-bundle.sh#L26), so including `build/` in the `package.json` `files` field is not necessary.

Instead, I'm explicitly adding in entries for the built `sw-toolbox.js` and corresponding sourcemap, which should hopefully correspond to what `npm-publish-scripts` will copy over.