### PR TITLE
export fetchAndCache so it can be used by user code

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -101,3 +101,6 @@ Causes the resource at `url` to be added to the cache and returns a Promise that
 
 ### `toolbox.uncache(url, options)`
 Causes the resource at `url` to be removed from the cache and returns a Promise that resolves to true if the cache entry is deleted. The `options` parameter supports  the `debug` and `cache` [global options](#global-options).
+
+### `toolbox.fetchAndCache(request, options)`
+Fetches the request from the network and adds the response to the cache. The `options` parameter supports the `debug` and `cache` [global options](#global-options).

--- a/lib/sw-toolbox.js
+++ b/lib/sw-toolbox.js
@@ -42,5 +42,6 @@ module.exports = {
   options: options,
   cache: helpers.cache,
   uncache: helpers.uncache,
-  precache: helpers.precache
+  precache: helpers.precache,
+  fetchAndCache: helpers.fetchAndCache
 };


### PR DESCRIPTION
I think it would be helpful to expose helpers.fetchAndCache so that users that implement their own handlers can use it.  It would also be nice to expose the entire helpers module, but perhaps that's a bridge too far?
