### PR TITLE
Don't fail silently when someone tries to cache a non-GET request

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -21,8 +21,13 @@ var idbCacheExpiration = require('./idb-cache-expiration');
 function debug(message, options) {
   options = options || {};
   var flag = options.debug || globalOptions.debug;
+  var error = options.error;
   if (flag) {
-    console.log('[sw-toolbox] ' + message);
+    if (error) {
+      console.error('[sw-toolbox]', message);
+    } else {
+      console.log('[sw-toolbox] ' + message);
+    }
   }
 }
 
@@ -46,23 +51,29 @@ function fetchAndCache(request, options) {
     // Since this is not part of the promise chain, it will be done
     // asynchronously and will not block the response from being returned to the
     // page.
-    if (request.method === 'GET' && successResponses.test(response.status)) {
-      openCache(options).then(function(cache) {
-        cache.put(request, response).then(function() {
-          // If any of the options are provided in options.cache then use them.
-          // Do not fallback to the global options for any that are missing
-          // unless they are all missing.
-          var cacheOptions = options.cache || globalOptions.cache;
+    if (request.method === 'GET') {
+      if (successResponses.test(response.status)) {
+        openCache(options).then(function(cache) {
+          cache.put(request, response).then(function() {
+            // If any of the options are provided in options.cache then use them.
+            // Do not fallback to the global options for any that are missing
+            // unless they are all missing.
+            var cacheOptions = options.cache || globalOptions.cache;
 
-          // Only run the cache expiration logic if at least one of the maximums
-          // is set, and if we have a name for the cache that the options are
-          // being applied to.
-          if ((cacheOptions.maxEntries || cacheOptions.maxAgeSeconds) &&
-              cacheOptions.name) {
-            queueCacheExpiration(request, cache, cacheOptions);
-          }
+            // Only run the cache expiration logic if at least one of the maximums
+            // is set, and if we have a name for the cache that the options are
+            // being applied to.
+            if ((cacheOptions.maxEntries || cacheOptions.maxAgeSeconds) &&
+                cacheOptions.name) {
+              queueCacheExpiration(request, cache, cacheOptions);
+            }
+          });
         });
-      });
+      }
+    } else {
+      debug(new TypeError('Request method \'' + request.method +
+          '\' is unsupported'),
+        {error: true, debug: options.debug});
     }
 
     return response.clone();


### PR DESCRIPTION
I was unaware (SW n00b) that one could not cache a non-GET request. Unfortunately, `sw-toolbox` has a check for the method of the request and fails silently if it's not a GET request. A simple error in the log would have helped a lot and saved me much time in debugging.