### PR TITLE
Support configuring a custom function with the request object as an input param for URL pattern

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -20,23 +20,23 @@ var url = new URL('./', self.location);
 var basePath = url.pathname;
 var pathRegexp = require('path-to-regexp');
 
-var Route = function(method, path, handler, options) {
-  if (path instanceof RegExp) {
-    this.fullUrlRegExp = path;
-  } else if (typeof path === 'function') {
-    this.funcUrlPattern = path;
+var Route = function(method, pathOrFunc, handler, options) {
+  if (pathOrFunc instanceof RegExp) {
+    this.fullUrlRegExp = pathOrFunc;
+  } else if (typeof pathOrFunc === 'function') {
+    this.funcUrlPattern = pathOrFunc;
   } else {
     // The URL() constructor can't parse express-style routes as they are not
     // valid urls. This means we have to manually manipulate relative urls into
     // absolute ones. This check is extremely naive but implementing a tweaked
     // version of the full algorithm seems like overkill
     // (https://url.spec.whatwg.org/#concept-basic-url-parser)
-    if (path.indexOf('/') !== 0) {
-      path = basePath + path;
+    if (pathOrFunc.indexOf('/') !== 0) {
+      pathOrFunc = basePath + pathOrFunc;
     }
 
     this.keys = [];
-    this.regexp = pathRegexp(path, this.keys);
+    this.regexp = pathRegexp(pathOrFunc, this.keys);
   }
 
   this.method = method;

--- a/lib/route.js
+++ b/lib/route.js
@@ -23,6 +23,8 @@ var pathRegexp = require('path-to-regexp');
 var Route = function(method, path, handler, options) {
   if (path instanceof RegExp) {
     this.fullUrlRegExp = path;
+  } else if (typeof path === 'function') {
+    this.funcUrlPattern = path;
   } else {
     // The URL() constructor can't parse express-style routes as they are not
     // valid urls. This means we have to manually manipulate relative urls into

--- a/lib/router.js
+++ b/lib/router.js
@@ -17,24 +17,38 @@
 
 var Route = require('./route');
 var helpers = require('./helpers');
+var FUNC_PAT = 'funcUrlPattern';
 
 function regexEscape(s) {
   return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-var keyMatch = function(map, string) {
+var keyMatch = function(map, string, urlPatType) {
   // This would be better written as a for..of loop, but that would break the
   // minifyify process in the build.
   var entriesIterator = map.entries();
   var item = entriesIterator.next();
   var matches = [];
-  while (!item.done) {
-    var pattern = new RegExp(item.value[0]);
-    if (pattern.test(string)) {
-      matches.push(item.value[1]);
+
+  // if the urlPattern is a custom function, match with this
+  if (urlPatType === FUNC_PAT) {
+    while (!item.done) {
+      var funcUrlPattern = item.value[0];
+      if (typeof funcUrlPattern === 'function' && funcUrlPattern(string)) {
+        matches.push(item.value[1]);
+      }
+      item = entriesIterator.next();
     }
-    item = entriesIterator.next();
+  } else {
+    while (!item.done) {
+      var pattern = new RegExp(item.value[0]);
+      if (pattern.test(string)) {
+        matches.push(item.value[1]);
+      }
+      item = entriesIterator.next();
+    }
   }
+
   return matches;
 };
 
@@ -60,6 +74,9 @@ Router.prototype.add = function(method, path, handler, options) {
     // from Express-style paths + origins. Since we can use any object as the
     // key in a Map, let's use the RegExp constructor!
     origin = RegExp;
+  } else if (typeof path === 'function') {
+    // if urlPattern is a function
+    origin = FUNC_PAT;
   } else {
     origin = options.origin || self.location.origin;
     if (origin instanceof RegExp) {
@@ -83,13 +100,20 @@ Router.prototype.add = function(method, path, handler, options) {
   }
 
   var routeMap = methodMap.get(method);
-  var regExp = route.regexp || route.fullUrlRegExp;
 
-  if (routeMap.has(regExp.source)) {
-    helpers.debug('"' + path + '" resolves to same regex as existing route.');
+
+  // urlPattern is a custom function
+  if (origin === 'funcUrlPattern') {
+    routeMap.set(route.funcUrlPattern, route);
+  } else {
+    var regExp = route.regexp || route.fullUrlRegExp;
+
+    if (routeMap.has(regExp.source)) {
+      helpers.debug('"' + path + '" resolves to same regex as existing route.');
+    }
+
+    routeMap.set(regExp.source, route);
   }
-
-  routeMap.set(regExp.source, route);
 };
 
 Router.prototype.matchMethod = function(method, url) {
@@ -103,10 +127,11 @@ Router.prototype.matchMethod = function(method, url) {
   // If there's no match, we next check for a match against any RegExp routes,
   // where the RegExp in question matches the full URL (both origin and path).
   return this._match(method, keyMatch(this.routes, origin), path) ||
-    this._match(method, [this.routes.get(RegExp)], url);
+    this._match(method, [this.routes.get(RegExp)], url) ||
+    this._match(method, [this.routes.get(FUNC_PAT)], url, FUNC_PAT);
 };
 
-Router.prototype._match = function(method, methodMaps, pathOrUrl) {
+Router.prototype._match = function(method, methodMaps, pathOrUrl, urlPatType) {
   if (methodMaps.length === 0) {
     return null;
   }
@@ -115,7 +140,7 @@ Router.prototype._match = function(method, methodMaps, pathOrUrl) {
     var methodMap = methodMaps[i];
     var routeMap = methodMap && methodMap.get(method.toLowerCase());
     if (routeMap) {
-      var routes = keyMatch(routeMap, pathOrUrl);
+      var routes = keyMatch(routeMap, pathOrUrl, urlPatType);
       if (routes.length > 0) {
         return routes[0].makeHandler(pathOrUrl);
       }

--- a/lib/router.js
+++ b/lib/router.js
@@ -103,7 +103,7 @@ Router.prototype.add = function(method, path, handler, options) {
 
 
   // urlPattern is a custom function
-  if (origin === 'funcUrlPattern') {
+  if (origin === FUNC_PAT) {
     routeMap.set(route.funcUrlPattern, route);
   } else {
     var regExp = route.regexp || route.fullUrlRegExp;

--- a/lib/router.js
+++ b/lib/router.js
@@ -23,7 +23,7 @@ function regexEscape(s) {
   return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-var keyMatch = function(map, string, urlPatType) {
+var keyMatch = function(map, pathOrUrlOrRes, urlPatType) {
   // This would be better written as a for..of loop, but that would break the
   // minifyify process in the build.
   var entriesIterator = map.entries();
@@ -34,7 +34,7 @@ var keyMatch = function(map, string, urlPatType) {
   if (urlPatType === FUNC_PAT) {
     while (!item.done) {
       var funcUrlPattern = item.value[0];
-      if (typeof funcUrlPattern === 'function' && funcUrlPattern(string)) {
+      if (funcUrlPattern(pathOrUrlOrRes)) {
         matches.push(item.value[1]);
       }
       item = entriesIterator.next();
@@ -42,7 +42,7 @@ var keyMatch = function(map, string, urlPatType) {
   } else {
     while (!item.done) {
       var pattern = new RegExp(item.value[0]);
-      if (pattern.test(string)) {
+      if (pattern.test(pathOrUrlOrRes)) {
         matches.push(item.value[1]);
       }
       item = entriesIterator.next();
@@ -116,8 +116,8 @@ Router.prototype.add = function(method, path, handler, options) {
   }
 };
 
-Router.prototype.matchMethod = function(method, url) {
-  var urlObject = new URL(url);
+Router.prototype.matchMethod = function(method, request) {
+  var urlObject = new URL(request.url);
   var origin = urlObject.origin;
   var path = urlObject.pathname;
 
@@ -127,11 +127,11 @@ Router.prototype.matchMethod = function(method, url) {
   // If there's no match, we next check for a match against any RegExp routes,
   // where the RegExp in question matches the full URL (both origin and path).
   return this._match(method, keyMatch(this.routes, origin), path) ||
-    this._match(method, [this.routes.get(RegExp)], url) ||
-    this._match(method, [this.routes.get(FUNC_PAT)], url, FUNC_PAT);
+    this._match(method, [this.routes.get(RegExp)], request.url) ||
+    this._match(method, [this.routes.get(FUNC_PAT)], request, FUNC_PAT);
 };
 
-Router.prototype._match = function(method, methodMaps, pathOrUrl, urlPatType) {
+Router.prototype._match = function(method, methodMaps, pathOrUrlOrRes, urlPat) {
   if (methodMaps.length === 0) {
     return null;
   }
@@ -140,9 +140,9 @@ Router.prototype._match = function(method, methodMaps, pathOrUrl, urlPatType) {
     var methodMap = methodMaps[i];
     var routeMap = methodMap && methodMap.get(method.toLowerCase());
     if (routeMap) {
-      var routes = keyMatch(routeMap, pathOrUrl, urlPatType);
+      var routes = keyMatch(routeMap, pathOrUrlOrRes, urlPat);
       if (routes.length > 0) {
-        return routes[0].makeHandler(pathOrUrl);
+        return routes[0].makeHandler(pathOrUrlOrRes);
       }
     }
   }
@@ -151,8 +151,8 @@ Router.prototype._match = function(method, methodMaps, pathOrUrl, urlPatType) {
 };
 
 Router.prototype.match = function(request) {
-  return this.matchMethod(request.method, request.url) ||
-      this.matchMethod('any', request.url);
+  return this.matchMethod(request.method, request) ||
+      this.matchMethod('any', request);
 };
 
 module.exports = new Router();

--- a/lib/router.js
+++ b/lib/router.js
@@ -23,7 +23,7 @@ function regexEscape(s) {
   return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-var keyMatch = function(map, pathOrUrlOrRes) {
+var keyMatch = function(map, stringOrRes) {
   // This would be better written as a for..of loop, but that would break the
   // minifyify process in the build.
   var entriesIterator = map.entries();
@@ -34,7 +34,7 @@ var keyMatch = function(map, pathOrUrlOrRes) {
   if (typeof item.value[0] === 'function') {
     while (!item.done) {
       var funcUrlPattern = item.value[0];
-      if (funcUrlPattern(pathOrUrlOrRes)) {
+      if (funcUrlPattern(stringOrRes)) {
         matches.push(item.value[1]);
       }
       item = entriesIterator.next();
@@ -42,7 +42,7 @@ var keyMatch = function(map, pathOrUrlOrRes) {
   } else {
     while (!item.done) {
       var pattern = new RegExp(item.value[0]);
-      if (pattern.test(pathOrUrlOrRes)) {
+      if (pattern.test(stringOrRes)) {
         matches.push(item.value[1]);
       }
       item = entriesIterator.next();

--- a/lib/router.js
+++ b/lib/router.js
@@ -30,23 +30,21 @@ var keyMatch = function(map, stringOrRes) {
   var item = entriesIterator.next();
   var matches = [];
 
-  // if the urlPattern is a custom function, match with this
-  if (typeof item.value[0] === 'function') {
-    while (!item.done) {
+  while (!item.done) {
+    // if the urlPattern is a custom function, match with this
+    if (typeof item.value[0] === 'function') {
       var funcUrlPattern = item.value[0];
       if (funcUrlPattern(stringOrRes)) {
         matches.push(item.value[1]);
       }
-      item = entriesIterator.next();
-    }
-  } else {
-    while (!item.done) {
+    } else {
       var pattern = new RegExp(item.value[0]);
       if (pattern.test(stringOrRes)) {
         matches.push(item.value[1]);
       }
-      item = entriesIterator.next();
     }
+
+    item = entriesIterator.next();
   }
 
   return matches;
@@ -109,7 +107,8 @@ Router.prototype.add = function(method, pathOrFunc, handler, options) {
     var regExp = route.regexp || route.fullUrlRegExp;
 
     if (routeMap.has(regExp.source)) {
-      helpers.debug('"' + pathOrFunc + '" resolves to same regex as existing route.');
+      var t = '"' + pathOrFunc + '" resolves to same regex as existing route.';
+      helpers.debug(t);
     }
 
     routeMap.set(regExp.source, route);

--- a/lib/router.js
+++ b/lib/router.js
@@ -23,7 +23,7 @@ function regexEscape(s) {
   return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-var keyMatch = function(map, pathOrUrlOrRes, urlPatType) {
+var keyMatch = function(map, pathOrUrlOrRes) {
   // This would be better written as a for..of loop, but that would break the
   // minifyify process in the build.
   var entriesIterator = map.entries();
@@ -31,7 +31,7 @@ var keyMatch = function(map, pathOrUrlOrRes, urlPatType) {
   var matches = [];
 
   // if the urlPattern is a custom function, match with this
-  if (urlPatType === FUNC_PAT) {
+  if (typeof item.value[0] === 'function') {
     while (!item.done) {
       var funcUrlPattern = item.value[0];
       if (funcUrlPattern(pathOrUrlOrRes)) {
@@ -60,21 +60,21 @@ var Router = function() {
 };
 
 ['get', 'post', 'put', 'delete', 'head', 'any'].forEach(function(method) {
-  Router.prototype[method] = function(path, handler, options) {
-    return this.add(method, path, handler, options);
+  Router.prototype[method] = function(pathOrFunc, handler, options) {
+    return this.add(method, pathOrFunc, handler, options);
   };
 });
 
-Router.prototype.add = function(method, path, handler, options) {
+Router.prototype.add = function(method, pathOrFunc, handler, options) {
   options = options || {};
   var origin;
 
-  if (path instanceof RegExp) {
+  if (pathOrFunc instanceof RegExp) {
     // We need a unique key to use in the Map to distinguish RegExp paths
     // from Express-style paths + origins. Since we can use any object as the
     // key in a Map, let's use the RegExp constructor!
     origin = RegExp;
-  } else if (typeof path === 'function') {
+  } else if (typeof pathOrFunc === 'function') {
     // if urlPattern is a function
     origin = FUNC_PAT;
   } else {
@@ -88,7 +88,7 @@ Router.prototype.add = function(method, path, handler, options) {
 
   method = method.toLowerCase();
 
-  var route = new Route(method, path, handler, options);
+  var route = new Route(method, pathOrFunc, handler, options);
 
   if (!this.routes.has(origin)) {
     this.routes.set(origin, new Map());
@@ -109,7 +109,7 @@ Router.prototype.add = function(method, path, handler, options) {
     var regExp = route.regexp || route.fullUrlRegExp;
 
     if (routeMap.has(regExp.source)) {
-      helpers.debug('"' + path + '" resolves to same regex as existing route.');
+      helpers.debug('"' + pathOrFunc + '" resolves to same regex as existing route.');
     }
 
     routeMap.set(regExp.source, route);
@@ -128,10 +128,10 @@ Router.prototype.matchMethod = function(method, request) {
   // where the RegExp in question matches the full URL (both origin and path).
   return this._match(method, keyMatch(this.routes, origin), path) ||
     this._match(method, [this.routes.get(RegExp)], request.url) ||
-    this._match(method, [this.routes.get(FUNC_PAT)], request, FUNC_PAT);
+    this._match(method, [this.routes.get(FUNC_PAT)], request);
 };
 
-Router.prototype._match = function(method, methodMaps, pathOrUrlOrRes, urlPat) {
+Router.prototype._match = function(method, methodMaps, pathOrUrlOrRes) {
   if (methodMaps.length === 0) {
     return null;
   }
@@ -140,7 +140,7 @@ Router.prototype._match = function(method, methodMaps, pathOrUrlOrRes, urlPat) {
     var methodMap = methodMaps[i];
     var routeMap = methodMap && methodMap.get(method.toLowerCase());
     if (routeMap) {
-      var routes = keyMatch(routeMap, pathOrUrlOrRes, urlPat);
+      var routes = keyMatch(routeMap, pathOrUrlOrRes);
       if (routes.length > 0) {
         return routes[0].makeHandler(pathOrUrlOrRes);
       }

--- a/test/browser-tests/router-methods/router-methods.js
+++ b/test/browser-tests/router-methods/router-methods.js
@@ -57,6 +57,21 @@ describe('Test router.{' + availableMethods.join(',') + '} methods', () => {
     });
   };
 
+  const performTestResIn = (method, swUrl, request, expectedString) => {
+    return swUtils.activateSW(swUrl + '?method=' + method)
+    .then(() => {
+      if (method === 'any') {
+        return Promise.all(
+          availableMethods.map(fetchMethod => {
+            return performFetch(fetchMethod, request.url, expectedString);
+          })
+        );
+      }
+
+      return performFetch(method, request.url, expectedString);
+    });
+  };
+
   const addMochaTests = method => {
     describe('Testing router.' + method, function() {
       it('should return response for absolute url', () => {
@@ -87,20 +102,13 @@ describe('Test router.{' + availableMethods.join(',') + '} methods', () => {
       });
 
       it('should return the variable from a function pattern ok', () => {
-        return performTest(
+        return performTestResIn(
           method,
           serviceWorkersFolder + '/function-match.js',
-          '/test/match/function/pattern/ok',
-          'function match ok'
-        );
-      });
-
-      it('should return the variable from a function pattern err', () => {
-        return performTest(
-          method,
-          serviceWorkersFolder + '/function-match.js',
-          '/test/match/function/pattern/err',
-          'function match err'
+          {
+            url: '/test/match/function/pattern/ok'
+          },
+          location.origin + '/test/match/function/pattern/ok'
         );
       });
 

--- a/test/browser-tests/router-methods/router-methods.js
+++ b/test/browser-tests/router-methods/router-methods.js
@@ -86,6 +86,24 @@ describe('Test router.{' + availableMethods.join(',') + '} methods', () => {
         );
       });
 
+      it('should return the variable from a function pattern ok', () => {
+        return performTest(
+          method,
+          serviceWorkersFolder + '/function-match.js',
+          '/test/match/function/pattern/ok',
+          'function match ok'
+        );
+      });
+
+      it('should return the variable from a function pattern err', () => {
+        return performTest(
+          method,
+          serviceWorkersFolder + '/function-match.js',
+          '/test/match/function/pattern/err',
+          'function match err'
+        );
+      });
+
      // TODO: Find out correct behaviour https://github.com/GoogleChrome/sw-toolbox/issues/86
       it.skip('should throw an error for route with an origin defined in sw testing request for full url', () => {
         return performTest(

--- a/test/browser-tests/router-methods/serviceworkers/function-match.js
+++ b/test/browser-tests/router-methods/serviceworkers/function-match.js
@@ -1,0 +1,43 @@
+/*
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+/* eslint-env worker, serviceworker */
+
+importScripts('/sw-toolbox.js');
+importScripts('/test/data/skip-and-claim.js');
+importScripts('/test/data/router-methods-helper.js');
+
+const method = self.getMethodToTest();
+
+self.toolbox.router[method](
+  function(request) {
+    return request.indexOf('/ok') !== -1;
+  },
+  function() {
+    return new Response('function match ok');
+  });
+
+self.toolbox.router[method](
+  function(request) {
+    return request.indexOf('/err') !== -1;
+  },
+  function() {
+    return new Response('function match err');
+  });
+
+

--- a/test/browser-tests/router-methods/serviceworkers/function-match.js
+++ b/test/browser-tests/router-methods/serviceworkers/function-match.js
@@ -26,18 +26,9 @@ const method = self.getMethodToTest();
 
 self.toolbox.router[method](
   function(request) {
-    return request.indexOf('/ok') !== -1;
+    return request.url.indexOf('/ok') !== -1;
   },
-  function() {
-    return new Response('function match ok');
-  });
-
-self.toolbox.router[method](
   function(request) {
-    return request.indexOf('/err') !== -1;
-  },
-  function() {
-    return new Response('function match err');
+    return new Response(request.url);
   });
-
 


### PR DESCRIPTION
sw-toolbox has two  options, Express-style Routes and 
Regular Expression Routes,  for configuring the routes,  but it's not flexible enough for users. If it can support  configuring a custom function with the request object as an input param for url pattern，users can do more processing according to the request object.  In order to meet this need, I have changed  two files, `lib/router.js` and `lib/route.js`,  and added some test cases in the test folder. These changes will not affect the original Routes config.Your prompt attention to this matter will be appreciated.

An example of using Function Expression routing include:
```js
toolbox.router.get(
function(request){
  // users can get request object, do some processing accroding to the request object and return a boolean value
  if (request && reqest.headers && request.headers.referer) {
     return true;
  } 
}, apiHandler);
```