### PR TITLE
Support configuring a custom function with the request object as an input param for URL pattern

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -20,21 +20,23 @@ var url = new URL('./', self.location);
 var basePath = url.pathname;
 var pathRegexp = require('path-to-regexp');
 
-var Route = function(method, path, handler, options) {
-  if (path instanceof RegExp) {
-    this.fullUrlRegExp = path;
+var Route = function(method, pathOrFunc, handler, options) {
+  if (pathOrFunc instanceof RegExp) {
+    this.fullUrlRegExp = pathOrFunc;
+  } else if (typeof pathOrFunc === 'function') {
+    this.funcUrlPattern = pathOrFunc;
   } else {
     // The URL() constructor can't parse express-style routes as they are not
     // valid urls. This means we have to manually manipulate relative urls into
     // absolute ones. This check is extremely naive but implementing a tweaked
     // version of the full algorithm seems like overkill
     // (https://url.spec.whatwg.org/#concept-basic-url-parser)
-    if (path.indexOf('/') !== 0) {
-      path = basePath + path;
+    if (pathOrFunc.indexOf('/') !== 0) {
+      pathOrFunc = basePath + pathOrFunc;
     }
 
     this.keys = [];
-    this.regexp = pathRegexp(path, this.keys);
+    this.regexp = pathRegexp(pathOrFunc, this.keys);
   }
 
   this.method = method;

--- a/lib/router.js
+++ b/lib/router.js
@@ -17,24 +17,36 @@
 
 var Route = require('./route');
 var helpers = require('./helpers');
+var FUNC_PAT = 'funcUrlPattern';
 
 function regexEscape(s) {
   return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-var keyMatch = function(map, string) {
+var keyMatch = function(map, stringOrRes) {
   // This would be better written as a for..of loop, but that would break the
   // minifyify process in the build.
   var entriesIterator = map.entries();
   var item = entriesIterator.next();
   var matches = [];
+
   while (!item.done) {
-    var pattern = new RegExp(item.value[0]);
-    if (pattern.test(string)) {
-      matches.push(item.value[1]);
+    // if the urlPattern is a custom function, match with this
+    if (typeof item.value[0] === 'function') {
+      var funcUrlPattern = item.value[0];
+      if (funcUrlPattern(stringOrRes)) {
+        matches.push(item.value[1]);
+      }
+    } else {
+      var pattern = new RegExp(item.value[0]);
+      if (pattern.test(stringOrRes)) {
+        matches.push(item.value[1]);
+      }
     }
+
     item = entriesIterator.next();
   }
+
   return matches;
 };
 
@@ -46,20 +58,23 @@ var Router = function() {
 };
 
 ['get', 'post', 'put', 'delete', 'head', 'any'].forEach(function(method) {
-  Router.prototype[method] = function(path, handler, options) {
-    return this.add(method, path, handler, options);
+  Router.prototype[method] = function(pathOrFunc, handler, options) {
+    return this.add(method, pathOrFunc, handler, options);
   };
 });
 
-Router.prototype.add = function(method, path, handler, options) {
+Router.prototype.add = function(method, pathOrFunc, handler, options) {
   options = options || {};
   var origin;
 
-  if (path instanceof RegExp) {
+  if (pathOrFunc instanceof RegExp) {
     // We need a unique key to use in the Map to distinguish RegExp paths
     // from Express-style paths + origins. Since we can use any object as the
     // key in a Map, let's use the RegExp constructor!
     origin = RegExp;
+  } else if (typeof pathOrFunc === 'function') {
+    // if urlPattern is a function
+    origin = FUNC_PAT;
   } else {
     origin = options.origin || self.location.origin;
     if (origin instanceof RegExp) {
@@ -71,7 +86,7 @@ Router.prototype.add = function(method, path, handler, options) {
 
   method = method.toLowerCase();
 
-  var route = new Route(method, path, handler, options);
+  var route = new Route(method, pathOrFunc, handler, options);
 
   if (!this.routes.has(origin)) {
     this.routes.set(origin, new Map());
@@ -83,17 +98,25 @@ Router.prototype.add = function(method, path, handler, options) {
   }
 
   var routeMap = methodMap.get(method);
-  var regExp = route.regexp || route.fullUrlRegExp;
 
-  if (routeMap.has(regExp.source)) {
-    helpers.debug('"' + path + '" resolves to same regex as existing route.');
+
+  // urlPattern is a custom function
+  if (origin === FUNC_PAT) {
+    routeMap.set(route.funcUrlPattern, route);
+  } else {
+    var regExp = route.regexp || route.fullUrlRegExp;
+
+    if (routeMap.has(regExp.source)) {
+      var t = '"' + pathOrFunc + '" resolves to same regex as existing route.';
+      helpers.debug(t);
+    }
+
+    routeMap.set(regExp.source, route);
   }
-
-  routeMap.set(regExp.source, route);
 };
 
-Router.prototype.matchMethod = function(method, url) {
-  var urlObject = new URL(url);
+Router.prototype.matchMethod = function(method, request) {
+  var urlObject = new URL(request.url);
   var origin = urlObject.origin;
   var path = urlObject.pathname;
 
@@ -103,10 +126,11 @@ Router.prototype.matchMethod = function(method, url) {
   // If there's no match, we next check for a match against any RegExp routes,
   // where the RegExp in question matches the full URL (both origin and path).
   return this._match(method, keyMatch(this.routes, origin), path) ||
-    this._match(method, [this.routes.get(RegExp)], url);
+    this._match(method, [this.routes.get(RegExp)], request.url) ||
+    this._match(method, [this.routes.get(FUNC_PAT)], request);
 };
 
-Router.prototype._match = function(method, methodMaps, pathOrUrl) {
+Router.prototype._match = function(method, methodMaps, pathOrUrlOrRes) {
   if (methodMaps.length === 0) {
     return null;
   }
@@ -115,9 +139,9 @@ Router.prototype._match = function(method, methodMaps, pathOrUrl) {
     var methodMap = methodMaps[i];
     var routeMap = methodMap && methodMap.get(method.toLowerCase());
     if (routeMap) {
-      var routes = keyMatch(routeMap, pathOrUrl);
+      var routes = keyMatch(routeMap, pathOrUrlOrRes);
       if (routes.length > 0) {
-        return routes[0].makeHandler(pathOrUrl);
+        return routes[0].makeHandler(pathOrUrlOrRes);
       }
     }
   }
@@ -126,8 +150,8 @@ Router.prototype._match = function(method, methodMaps, pathOrUrl) {
 };
 
 Router.prototype.match = function(request) {
-  return this.matchMethod(request.method, request.url) ||
-      this.matchMethod('any', request.url);
+  return this.matchMethod(request.method, request) ||
+      this.matchMethod('any', request);
 };
 
 module.exports = new Router();

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint": "^3.13.1",
     "eslint-config-google": "^0.7.1",
     "express": "^4.13.3",
-    "geckodriver": "^1.6.1",
+    "geckodriver": "1.6.1",
     "gulp": "^3.9.0",
     "gulp-eslint": "^3.0.1",
     "gulp-gh-pages": "^0.5.4",

--- a/test/browser-tests/router-methods/router-methods.js
+++ b/test/browser-tests/router-methods/router-methods.js
@@ -57,6 +57,21 @@ describe('Test router.{' + availableMethods.join(',') + '} methods', () => {
     });
   };
 
+  const performTestResIn = (method, swUrl, request, expectedString) => {
+    return swUtils.activateSW(swUrl + '?method=' + method)
+    .then(() => {
+      if (method === 'any') {
+        return Promise.all(
+          availableMethods.map(fetchMethod => {
+            return performFetch(fetchMethod, request.url, expectedString);
+          })
+        );
+      }
+
+      return performFetch(method, request.url, expectedString);
+    });
+  };
+
   const addMochaTests = method => {
     describe('Testing router.' + method, function() {
       it('should return response for absolute url', () => {
@@ -83,6 +98,17 @@ describe('Test router.{' + availableMethods.join(',') + '} methods', () => {
           serviceWorkersFolder + '/variable-match.js',
           '/test/match/echo-this/pattern',
           'echo-this'
+        );
+      });
+
+      it('should return the variable from a function pattern ok', () => {
+        return performTestResIn(
+          method,
+          serviceWorkersFolder + '/function-match.js',
+          {
+            url: '/test/match/function/pattern/ok'
+          },
+          location.origin + '/test/match/function/pattern/ok'
         );
       });
 

--- a/test/browser-tests/router-methods/serviceworkers/function-match.js
+++ b/test/browser-tests/router-methods/serviceworkers/function-match.js
@@ -1,0 +1,34 @@
+/*
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+/* eslint-env worker, serviceworker */
+
+importScripts('/sw-toolbox.js');
+importScripts('/test/data/skip-and-claim.js');
+importScripts('/test/data/router-methods-helper.js');
+
+const method = self.getMethodToTest();
+
+self.toolbox.router[method](
+  function(request) {
+    return request.url.indexOf('/ok') !== -1;
+  },
+  function(request) {
+    return new Response(request.url);
+  });
+


### PR DESCRIPTION
sw-toolbox has two  options, Express-style Routes and 
Regular Expression Routes,  for configuring the routes,  but it's not flexible enough for users. If it can support  configuring a custom function with the request object as an input param for url pattern，users can do more processing according to the request object.  In order to meet this need, I have changed  two files, `lib/router.js` and `lib/route.js`,  and added some test cases in the test folder. These changes will not affect the original Routes config.Your prompt attention to this matter will be appreciated.

An example of using Function Expression routing include:
```js
toolbox.router.get(
function(request){
  // users can get request object, do some processing accroding to the request object and return a boolean value
  if (request && reqest.headers && request.headers.referer) {
     return true;
  } 
}, apiHandler);
```