### PR TITLE
Ignore test directory in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   "ignore": [
     "**/.*",
     "lib",
-    "tests",
+    "test",
     "docs",
     "gulpfile.js"
   ]


### PR DESCRIPTION
Previously we were ignoring anything matching the glob pattern 'tests'. This looks like a typo to me as there is no file/directory in the root called that. There is, however, a 'tests' directory, which I presume this line was intended to catch.